### PR TITLE
feat: Implement f_orders_stats data mart

### DIFF
--- a/models/marts/f_orders_stats.sql
+++ b/models/marts/f_orders_stats.sql
@@ -1,8 +1,23 @@
 {{
-    config (
-      engine='MergeTree()',
-      order_by=['']
+    config(
+        engine='MergeTree()',
+        order_by=['O_ORDERYEAR', 'O_ORDERSTATUS', 'O_ORDERPRIORITY'],
+        partition_by='O_ORDERYEAR'
     )
 }}
 
-SELECT 1
+SELECT
+    toYear(O_ORDERDATE) AS O_ORDERYEAR,
+    O_ORDERSTATUS,
+    O_ORDERPRIORITY,
+    COUNT(DISTINCT O_ORDERKEY) AS num_orders,
+    COUNT(DISTINCT C_CUSTKEY) AS num_customers,
+    SUM(L_EXTENDEDPRICE * L_DISCOUNT) AS revenue
+FROM {{ ref('stg_lineitem') }} AS l
+INNER JOIN {{ ref('stg_orders') }} AS o ON o.O_ORDERKEY = l.L_ORDERKEY
+INNER JOIN {{ ref('stg_customer') }} AS c ON c.C_CUSTKEY = o.O_CUSTKEY
+WHERE 1=1
+GROUP BY
+    toYear(O_ORDERDATE),
+    O_ORDERSTATUS,
+    O_ORDERPRIORITY


### PR DESCRIPTION
**Цель:** Создать оптимизированную витрину данных `f_orders_stats` для аналитики заказов.


**Что сделано:**
- Реализована модель `f_orders_stats` с группировкой по году, статусу и приоритету заказа.
- Добавлены ключевые метрики:
  - `num_orders` — количество уникальных заказов (`COUNT(DISTINCT O_ORDERKEY)`);
  - `num_customers` — количество уникальных клиентов (`COUNT(DISTINCT C_CUSTKEY)`);
  - `revenue` — выручка с учётом скидки (`SUM(L_EXTENDEDPRICE * L_DISCOUNT)`).
- Настроены тесты для проверки целостности данных:
  - проверка общего количества заказов (1 500 000);
  - проверка количества строк (45).
- Оптимизирована конфигурация ClickHouse:
  - движок `MergeTree()`;
  - партиционирование по `O_ORDERYEAR`;
  - порядок хранения по ключевым полям (`order_by`).

**Проверка:**
- Локально модель построена: `dbt build -s f_orders_stats --full-refresh`
- Тесты прошли успешно: `dbt test -s f_orders_stats` → PASS=2
- Структура таблицы проверена: `DESCRIBE default.f_orders_stats`


**Связанные задачи:** #LAB-123

**Файлы:**
- `models/marts/f_orders_stats.sql`
- `tests/assert_f_orders_stats_num_orders.sql`
- `tests/assert_f_orders_stats_rowcount.sql`
